### PR TITLE
Fix malformed XML

### DIFF
--- a/releases/Black Hole.mra
+++ b/releases/Black Hole.mra
@@ -4,7 +4,7 @@
 	<setname>blkhole</setname>
 	<mratimestamp>20200427161917</mratimestamp>
 	<year>1981</year>
-	<manufacturer>TDS & MINTS</manufacturer>
+	<manufacturer>TDS &amp; MINTS</manufacturer>
 	<category>Space / Shooter</category>
 	<rbf>galaxian</rbf>
 	<switches default="FF,1F,02">


### PR DESCRIPTION
> The ampersand character (&) and the left angle bracket (<) must not appear in their literal form, except when used as markup delimiters, or within a comment, a processing instruction, or a CDATA section. If they are needed elsewhere, they must be escaped using either numeric character references or the strings " &amp; " and " &lt; " respectively.

source: https://www.w3.org/TR/xml/#syntax