### PR TITLE
Added "setname" to Mr.Do Nightmare and CleansweepTTL 

### DIFF
--- a/releases/Clean Sweep (TTL).mra
+++ b/releases/Clean Sweep (TTL).mra
@@ -11,7 +11,7 @@
 	<manufacturer>Ramtek</manufacturer>
 	<category>Maze</category>
 
-	<setname>cleanswttl</setname>
+	<setname>cleansweept</setname>
 	<parent></parent>
 	<mameversion>0226</mameversion>
 	<rbf>galaxian</rbf>

--- a/releases/Clean Sweep (TTL).mra
+++ b/releases/Clean Sweep (TTL).mra
@@ -11,7 +11,7 @@
 	<manufacturer>Ramtek</manufacturer>
 	<category>Maze</category>
 
-	<setname></setname>
+	<setname>cleanswttl</setname>
 	<parent></parent>
 	<mameversion>0226</mameversion>
 	<rbf>galaxian</rbf>

--- a/releases/Mr. Do Nightmare.mra
+++ b/releases/Mr. Do Nightmare.mra
@@ -11,7 +11,7 @@
 	<manufacturer>Crazy Ivan</manufacturer>
 	<category>Maze</category>
 
-	<setname></setname>
+	<setname>mrdonight</setname>
 	<parent></parent>
 	<mameversion>0220</mameversion>
 	<rbf>galaxian</rbf>


### PR DESCRIPTION
Found empty "setname" entries in Mr.Do Nightmare and CleansweepTTL MRA.
Both MRA's write **A.GALAXN** to **/tmp/CORENAME** which confuses my tty2oled add-on 😃 .