### PR TITLE
Fix Clean Sweep description fields

### DIFF
--- a/releases/Clean Sweep.mra
+++ b/releases/Clean Sweep.mra
@@ -14,7 +14,7 @@
 	<parent></parent>
 	<mameversion>0000</mameversion>
 	<rbf>galaxian</rbf>
-	<about>This is a homebrew version of the Vectrex game of the same name. See https://misterfpga.org/viewtopic.php?f=25&p=12248#p12248</about>
+	<about>This is a homebrew version of the Vectrex game of the same name.</about>
 
 	<resolution>15kHz</resolution>
 	<rotation>vertical (cw)</rotation>

--- a/releases/Clean Sweep.mra
+++ b/releases/Clean Sweep.mra
@@ -1,21 +1,20 @@
 <misterromdescription>
 	<name>Clean Sweep</name>
 	<region></region>
-	<homebrew>no</homebrew>
+	<homebrew>yes</homebrew>
 	<bootleg>no</bootleg>
-	<version>TTL</version>
 	<alternative></alternative>
 	<platform></platform>
 	<series></series>
-	<year>1974</year>
-	<manufacturer>Ramtek</manufacturer>
+	<year>1982</year>
+	<manufacturer>GCE</manufacturer>
 	<category>Maze</category>
 
 	<setname>cleansweept</setname>
 	<parent></parent>
-	<mameversion>0226</mameversion>
+	<mameversion>0000</mameversion>
 	<rbf>galaxian</rbf>
-	<about></about>
+	<about>This is a homebrew version of the Vectrex game of the same name. See https://misterfpga.org/viewtopic.php?f=25&p=12248#p12248</about>
 
 	<resolution>15kHz</resolution>
 	<rotation>vertical (cw)</rotation>


### PR DESCRIPTION
This MRA is not for the TTL-based Clean Sweep game published in 1974 (clearly, since it's running on Galaxian hardware that wasn't released until 1979). It's actually a homebrew version of a Vectrex game. See https://misterfpga.org/viewtopic.php?f=25&p=12248#p12248